### PR TITLE
Fix result link of the "Add Cursor Entity" section

### DIFF
--- a/content.md
+++ b/content.md
@@ -525,7 +525,7 @@ A-Frame.
 
 <img class="stretch" data-src="media/img/gaze.gif">
 
-[View Result](https://glitch.com/~aframe-school-cursor)  <!-- .element: class="cta-button glitch" -->
+[View Result](https://aframe-school-cursor.glitch.me/solution.html)  <!-- .element: class="cta-button glitch" -->
 
 ---
 


### PR DESCRIPTION
The link should goes to the result, not the project home.